### PR TITLE
leading padding shrinks test

### DIFF
--- a/src/Samples/Diamond.cs
+++ b/src/Samples/Diamond.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Text;
 
 namespace Samples
@@ -33,6 +34,27 @@ namespace Samples
                 yield return " A ";
                 yield return $"{c} {c}";
                 yield return " A ";
+            }
+        }
+
+        private static IEnumerable<string> Generate4(char c)
+        {
+            var length = (c - 'A' + 1) * 2 - 1;
+            var edge = "{0}" + new string(' ', Math.Max(length - 2, 0)) + "{0}";
+            var lastIndex = length - 1;
+            var aPadding = new string(' ', (length - 1) / 2);
+
+            for (int i = 0; i < length; i++)
+            {
+                if (i == 0 || i == lastIndex)
+                {
+                    yield return  aPadding + 'A' + aPadding;
+                }
+                else
+                {
+                    char x = (char)((i <= length / 2) ? ('A' + i) : (c - (i - length/2)));
+                    yield return string.Format(edge, x);
+                }
             }
         }
 

--- a/src/Samples/DiamondTests.cs
+++ b/src/Samples/DiamondTests.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using FsCheck;
 using FsCheck.Xunit;
+using Microsoft.FSharp.Collections;
 
 namespace Samples
 {
@@ -95,6 +96,15 @@ namespace Samples
         {
            var inputLetterRow = Diamond.Generate(c).ToArray().First(x => GetCharInRow(x) == c);
            return (inputLetterRow[0] != ' ' && inputLetterRow[^1] != ' ').ToProperty();
+        }
+
+        [Property(Arbitrary = new[] { typeof(LetterGenerator) })]
+        public Property LeadingPaddingOfTopHalfShrinks(char c)
+        {
+            var diamond = Diamond.Generate(c).ToArray();
+            var half = diamond.Length / 2;
+            var topHalf = diamond[..half];
+            return SeqModule.Windowed(2, topHalf.Select(x => CountLeadingSpaces(x))).All(x => x[0] > x[1]).ToProperty();
         }
 
         private int CountLeadingSpaces(string s)


### PR DESCRIPTION
Add a test to guard against generate methods that produce shapes like this:
```
--A--  
B---B
C---C
B---B
--A--
```
